### PR TITLE
Fix regexp in generated Ruby grammar to be compatible with 1.9 encodings

### DIFF
--- a/lib/parsejs/grammar.kpeg.rb
+++ b/lib/parsejs/grammar.kpeg.rb
@@ -938,7 +938,7 @@ class ParseJS::Parser < KPeg::CompiledParser
 
   # SourceCharacter = /[\x00-\xff]/n
   def _SourceCharacter
-    _tmp = scan(/\A(?-mix:[\x00-\xff])/)
+    _tmp = scan(/\A(?-mix:[\x00-\xff])/n)
     set_failed_rule :_SourceCharacter unless _tmp
     return _tmp
   end


### PR DESCRIPTION
In Ruby 1.9 parsejs raises this error:

```
../lib/parsejs/grammar.kpeg.rb:941: invalid multibyte escape: /\A(?-mix:[\x00-\xff])/
```

The grammar.kpeg properly lists the regexp with the //n suffix, but the translation layer is not  adding the suffix to the generated Ruby output. I'm not sure what tool is used to generate the output, so I've manually adjusted the Ruby code. I assume the third party tool has to be fixed to support this.
